### PR TITLE
Add container_name

### DIFF
--- a/UI/app.rb
+++ b/UI/app.rb
@@ -7,7 +7,7 @@ get "/" do
 end
 
 get "/config" do
-	response = HTTParty.get("http://dockvpn_serveconfig_1:8080")
+	response = HTTParty.get("http://serveconfig:8080")
     tempfile = Tempfile.new('client.ovpn')
     File.open(tempfile.path,'w') do |f|
        f.write response.body

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   dockvpn:
     build: ./DockVPN
     image: dockvpn
+    container_name: dockvpn
     privileged: true
     ports:
       - "443:443"
@@ -10,6 +11,7 @@ services:
   serveconfig:
     build: ./DockVPN
     image: dockvpn
+    container_name: serveconfig
     depends_on:
       - dockvpn
     volumes_from:
@@ -20,6 +22,7 @@ services:
   config-ui:
     build: ./UI
     image: vpn-config-ui
+    container_name: config-ui
     links: 
       - dockvpn
       - serveconfig


### PR DESCRIPTION
I add container_name because when I clone this project I clone in another folder name and it can't work  because of this `dockvpn_serveconfig_1`.